### PR TITLE
Add voice input and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ streamlit run app.py
 
 Provide your OpenAI API key in the sidebar when prompted.
 
+### Voice features
+
+You can ask questions by recording your voice directly in the browser or by uploading an audio file (`.wav`, `.mp3`, `.m4a`). The app transcribes your voice with OpenAI's speech-to-text and replies with both text and an audio answer.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 streamlit
+streamlit-mic-recorder
 numpy
 pypdf
 openai


### PR DESCRIPTION
## Summary
- add audio transcription and text-to-speech helpers
- enable asking questions via uploaded audio or in-browser recording
- play synthesized audio for answers

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement streamlit; Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab8a0608788330bb8acc9c3ea4dd4d