### PR TITLE
Add audio playback button

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ Provide your OpenAI API key in the sidebar when prompted.
 
 You can ask questions by recording your voice directly in the browser or by uploading an audio file (`.wav`, `.mp3`, `.m4a`). The app transcribes your voice with OpenAI's speech-to-text and replies with both text and an audio answer.
 
+After an answer appears, use the **🔊 Play Answer Audio** button to listen to the response.
+

--- a/app.py
+++ b/app.py
@@ -196,7 +196,11 @@ with col2:
     clear = st.button("Clear")
 
 if clear:
+    st.session_state.pop("last_answer", None)
     st.experimental_rerun()
+
+answer_box = st.empty()
+st.session_state.setdefault("last_answer", "")
 
 # System prompts
 tone_map = {
@@ -223,17 +227,20 @@ if go:
         if context else f"Question: {question}"
     )
 
-    st.markdown("**Answer:**")
-    placeholder = st.empty()
     collected = ""
     try:
         for token in ask_llm(client, model=model, system=system_prompt, user=user_prompt):
             collected += token
-            placeholder.markdown(collected)
+            answer_box.markdown(collected)
     except Exception as e:
         st.error(f"LLM error: {e}")
     if collected:
-        audio_out = text_to_speech(client, collected)
+        st.session_state["last_answer"] = collected
+
+if st.session_state.get("last_answer"):
+    answer_box.markdown(st.session_state["last_answer"])
+    if st.button("🔊 Play Answer Audio"):
+        audio_out = text_to_speech(client, st.session_state["last_answer"])
         if audio_out:
             st.audio(audio_out, format="audio/mp3")
 


### PR DESCRIPTION
## Summary
- store last answer text in session state
- add UI button to play answer audio via text-to-speech
- document audio playback option in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab8d13e608833082a86e0a0033a255