### PR TITLE
Handle ChoiceDelta in streaming responses

### DIFF
--- a/utils_ai.py
+++ b/utils_ai.py
@@ -81,7 +81,8 @@ def ask_llm_stream(
             stream=True,
         )
         for chunk in stream:
-            piece = getattr(chunk.choices[0].delta, "content", "")
+            delta = chunk.choices[0].delta
+            piece = delta.get("content", "") if isinstance(delta, dict) else getattr(delta, "content", "")
             if piece:
                 text += piece
                 placeholder.markdown(text)


### PR DESCRIPTION
## Summary
- robustly read streamed content by checking for dict vs object and using `delta.content` when available

## Testing
- `python - <<'PY'
from utils_ai import ask_llm_stream

class DummyDelta:
    def __init__(self, content):
        self.content = content

class DummyChoice:
    def __init__(self, delta):
        self.delta = delta

class DummyChunk:
    def __init__(self, delta, usage=None):
        self.choices = [DummyChoice(delta)]
        if usage is not None:
            self.usage = usage

class DummyStream:
    def __iter__(self):
        yield DummyChunk(DummyDelta("Hello"))
        yield DummyChunk({"content": " world"})
        yield DummyChunk(DummyDelta(""), usage={"prompt_tokens":1, "completion_tokens":2})

class DummyCompletions:
    def create(self, **kwargs):
        return DummyStream()

class DummyChat:
    def __init__(self):
        self.completions = DummyCompletions()

class DummyClient:
    def __init__(self):
        self.chat = DummyChat()

class DummyPlaceholder:
    def markdown(self, text):
        print("MARKDOWN:", text)
    def error(self, msg):
        print("ERROR:", msg)

client = DummyClient()
placeholder = DummyPlaceholder()
text, usage, latency = ask_llm_stream(client, "test-model", "sys", "user", placeholder)
print("RESULT:", text, usage, round(latency,3))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ae039af7dc8330be99f260cbf439ba