### PR TITLE
Only clear question text on new recording

### DIFF
--- a/app.py
+++ b/app.py
@@ -148,11 +148,13 @@ else:
     st.info("streamlit-mic-recorder not installed. Voice recording unavailable.")
 
 if recorded_audio:
-    st.session_state["last_recorded_audio"] = recorded_audio
-    audio_bytes, fmt, _ = audio_bytes_from_input(recorded_audio)
-    st.session_state["last_mic_audio_bytes"] = audio_bytes
-    st.session_state["last_mic_audio_fmt"] = fmt
-    st.session_state.pop("question_text", None)
+    # Only process and clear the question when a new recording is captured
+    if recorded_audio != st.session_state.get("last_recorded_audio"):
+        audio_bytes, fmt, _ = audio_bytes_from_input(recorded_audio)
+        st.session_state["last_mic_audio_bytes"] = audio_bytes
+        st.session_state["last_mic_audio_fmt"] = fmt
+        st.session_state["last_recorded_audio"] = recorded_audio
+        st.session_state.pop("question_text", None)
 
 if st.session_state.get("last_mic_audio_bytes"):
     bytes_ = st.session_state["last_mic_audio_bytes"]


### PR DESCRIPTION
## Summary
- Avoid clearing the question input unless a newly recorded audio differs from the previous one

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0c65b8ac8330881267c605c0398f