### PR TITLE
Normalize Safari audio formats to m4a

### DIFF
--- a/utils_io.py
+++ b/utils_io.py
@@ -50,6 +50,8 @@ def audio_bytes_from_input(recorded_audio: Union[dict, str]) -> Tuple[bytes, str
         fmt = fmt.split(";")[0]
         if fmt in ("x-wav", "wave"):
             fmt = "wav"
+        if fmt in ("aac", "m4a", "x-m4a"):
+            fmt = "m4a"
         return fmt or "wav"
 
     if isinstance(recorded_audio, dict):


### PR DESCRIPTION
## Summary
- ensure `utils_io._norm_fmt` maps AAC/M4A MIME types to the `m4a` extension
- verified transcription path uses `audio.m4a` for Safari-recorded audio

## Testing
- `python - <<'PY'
from utils_io import audio_bytes_from_input
import base64
for fmt in ['audio/aac', 'audio/m4a', 'audio/x-m4a', 'audio/wav', 'audio/x-wav', 'audio/wave']:
    b64 = base64.b64encode(b'test').decode()
    b, f, sr = audio_bytes_from_input({'bytes': b64, 'format': fmt})
    print(fmt, '->', f)
PY`
- `python - <<'PY'
from utils_ai import transcribe_cached

class DummyTranscriptions:
    def create(self, model, file):
        print('file name passed:', file.name)
        class Resp:
            text = 'ok'
        return Resp()

class DummyAudio:
    transcriptions = DummyTranscriptions()

class DummyClient:
    audio = DummyAudio()

client = DummyClient()
cache = {}
res = transcribe_cached(client, b'123', 'm4a', cache)
print('transcription:', res)
PY`
- `python -m py_compile utils_io.py utils_ai.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1b7cb43dc8330b1cc1a608a6c5120