### PR TITLE
Add Safari audio recording fallback

### DIFF
--- a/utils_io.py
+++ b/utils_io.py
@@ -50,7 +50,7 @@ def audio_bytes_from_input(recorded_audio: Union[dict, str]) -> Tuple[bytes, str
         fmt = fmt.split(";")[0]
         if fmt in ("x-wav", "wave"):
             fmt = "wav"
-        if fmt in ("aac", "m4a", "x-m4a"):
+        if fmt in ("aac", "m4a", "x-m4a", "mp4", "mp4a", "mpg4"):
             fmt = "m4a"
         return fmt or "wav"
 


### PR DESCRIPTION
## Summary
- add custom MediaRecorder component and file upload fallback for Safari
- normalize Safari audio mime types in `audio_bytes_from_input`

## Testing
- `python -m py_compile app.py utils_io.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1bd8e26708330bd7fd6753b7106f8