### PR TITLE
docs: add Safari compatibility and troubleshooting tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,21 @@ You can ask questions by recording your voice directly in the browser. The app t
 
 After an answer appears, use the **🔊 Play Answer Audio** button to listen to the response.
 
+### Safari Compatibility
+
+The in-browser voice recording relies on the MediaRecorder API, which is supported in Safari 14+
+on macOS Big Sur and iOS 14 or later. Older Safari versions may not expose this API, so the
+record button will be disabled or silently fail. Even on supported versions, Safari does not
+allow recording from background tabs and may take a moment to initialize the microphone.
+
+### Troubleshooting
+
+- **Enable microphone access**: When recording fails, ensure Safari has permission to use the
+  microphone. The first time you visit the app, Safari will prompt for access. You can change
+  this later in *System Preferences → Privacy → Microphone* (macOS) or *Settings → Safari →
+  Microphone* (iOS).
+- **Select the correct input**: If no audio is captured, click the camera/microphone icon in the
+  address bar to choose the right input device and refresh the page.
+- **Fallback upload**: When browser recording is unsupported or permission is denied, record
+  audio with another application and use the file upload option to submit your question.
+


### PR DESCRIPTION
## Summary
- document Safari 14+ requirements and limitations for in-browser recording
- add microphone permission, input selection, and file-upload fallback troubleshooting tips

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1bf2bf65883309e72a01e90117711